### PR TITLE
Crash when footer is not set

### DIFF
--- a/paseto.py
+++ b/paseto.py
@@ -33,7 +33,7 @@ class PasetoV2:
     header = b'v2.local.'
 
     @classmethod
-    def encrypt(cls, plaintext, key, footer='', nonce_for_unit_testing=''):
+    def encrypt(cls, plaintext: bytes, key: bytes, footer=b'', nonce_for_unit_testing='') -> bytes:
         if nonce_for_unit_testing:
             nonce = nonce_for_unit_testing
         else:
@@ -55,7 +55,7 @@ class PasetoV2:
         return token
 
     @classmethod
-    def decrypt(cls, token, key):
+    def decrypt(cls, token: bytes, key: bytes) -> dict:
         parts = token.split(b'.')
         footer = b''
         if len(parts) == 4:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pysodium
+pytest

--- a/test_paseto.py
+++ b/test_paseto.py
@@ -110,3 +110,19 @@ def test_encrypt(token):
     assert decrypted['message'] == token['message']
     if decrypted['footer']:
         assert decrypted['footer']== token['footer']
+
+def test_encrypt_with_footer_not_set():
+    message = b'Love is stronger than hate or fear'
+    raw_token = b'v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSXlvv8MsrNZs3vTSnGQG4qRM9ezDl880jFwknSA6JARj2qKhDHnlSHx1GSCizfcF019U'
+    output_token = paseto.PasetoV2.encrypt(
+        plaintext=message,
+        key=sym_key,
+        nonce_for_unit_testing=nonce
+    )
+    assert raw_token == token['raw']
+
+    decrypted = paseto.PasetoV2.decrypt(
+        token=raw_token,
+        key=sym_key,
+    )
+    assert decrypted['message'] == message


### PR DESCRIPTION
Hi,

When you don't set the `footer` value in `encrypt` method call, a  `TypeError: can't concat str to bytes` is throw.

Reproduce it with
```python
from paseto import PasetoV2
import secrets

PasetoV2.encrypt(
        plaintext=b'mytext',
        key=secrets.token_bytes(32),
    )
```

