### PR TITLE
Output compact, stable JSON by default.

### DIFF
--- a/paseto.py
+++ b/paseto.py
@@ -147,7 +147,7 @@ class PasetoV2:
 class JsonEncoder(object):
     @classmethod
     def dumps(cls, var):
-        return json.dumps(var).encode('utf8')
+        return json.dumps(var, sort_keys=True, separators=(',', ':')).encode('utf8')
 
     @classmethod
     def loads(cls, var):


### PR DESCRIPTION
The [RFC test vectors][1] all contain JSON without whitespace between JSON
components. This patch configures the default encoder to do the same, and to
sort the keys by default.

[1]: https://tools.ietf.org/html/draft-paragon-paseto-rfc-00#appendix-A.2

Signed-off-by: Martijn Pieters <mj@zopatista.com>