### PR TITLE
Remove nonce for tests

### DIFF
--- a/paseto.py
+++ b/paseto.py
@@ -48,7 +48,6 @@ class PasetoV2:
     valid_purposes = [b'local', b'public']
     local_header = b'v2.local.'
     public_header = b'v2.public.'
-    nonce_for_unit_testing = None
 
     @classmethod
     def encrypt(
@@ -57,14 +56,10 @@ class PasetoV2:
         key: bytes,
         footer=b'',
     ) -> bytes:
-        if cls.nonce_for_unit_testing:
-            nonce = cls.nonce_for_unit_testing
-            cls.nonce_for_unit_testing = None
-        else:
-            nonce = pysodium.randombytes(pysodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
+        nonce_key = pysodium.randombytes(pysodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
         nonce = pysodium.crypto_generichash(
             plaintext,
-            k=nonce,
+            k=nonce_key,
             outlen=pysodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES
         )
         ciphertext = pysodium.crypto_aead_xchacha20poly1305_ietf_encrypt(

--- a/test_paseto.py
+++ b/test_paseto.py
@@ -2,23 +2,7 @@ import json
 
 import pytest
 import paseto
-
-
-def _set_unit_test_only_nonce(nonce):
-    """
-    If you are trying to figure out how to set a nonce, DONT!
-
-    When calling parse/create, the nonce is automatically generated
-    using the libsodium functions, which are likely more secure than another
-    source.
-
-    Even when accessing PasetoV2 directly (not recommended), you should never
-    need to generate your own nonce.
-
-    The tests set a nonce because the tests need a deterministic nonce because
-    they have to compare the newly generated tokens with a pre-generated token.
-    """
-    paseto.PasetoV2.nonce_for_unit_testing = nonce  # don't do this in your code
+from unittest import mock
 
 
 def _encode(o):
@@ -39,6 +23,7 @@ public_key = bytes.fromhex(
 )
 
 
+@mock.patch('pysodium.randombytes')
 @pytest.mark.parametrize("token", [
     {
         'name': 'Test Vector 2E-1-1',
@@ -203,8 +188,8 @@ public_key = bytes.fromhex(
         'nonce': nonce2,
     },
 ])
-def test_encrypt(token):
-    _set_unit_test_only_nonce(token['nonce'])
+def test_encrypt(mock_randombytes, token):
+    mock_randombytes.return_value = token['nonce']
     output_token = paseto.PasetoV2.encrypt(
         plaintext=token['message'],
         key=token['key'],


### PR DESCRIPTION
Hello! I like your port, thanks for your work!

I would like to contribute with a PR to remove the hardcoded nonce_for_unit_tests value, by using mock to patch the functionality of pysodium.randombytes().